### PR TITLE
 Allow overriding default validator

### DIFF
--- a/lib/intl_phone_field.dart
+++ b/lib/intl_phone_field.dart
@@ -43,13 +43,11 @@ class IntlPhoneField extends StatefulWidget {
   /// An optional method that validates an input. Returns an error string to display if the input is invalid, or null otherwise.
   ///
   /// A [PhoneNumber] is passed to the validator as argument.
-  /// The validator can handle asynchronous validation when declared as a [Future].
-  /// Or run synchronously when declared as a [Function].
   ///
   /// By default, the validator checks whether the input number length is between selected country's phone numbers min and max length.
   /// If `disableLengthCheck` is not set to `true`, your validator returned value will be overwritten by the default validator.
   /// But, if `disableLengthCheck` is set to `true`, your validator will have to check phone number length itself.
-  final FutureOr<String?> Function(PhoneNumber?)? validator;
+  final FormFieldValidator<PhoneNumber>? validator;
 
   /// {@macro flutter.widgets.editableText.keyboardType}
   final TextInputType keyboardType;
@@ -427,6 +425,13 @@ class _IntlPhoneFieldState extends State<IntlPhoneField> {
         widget.onChanged?.call(phoneNumber);
       },
       validator: (value) {
+        if (widget.validator != null) {
+          return widget.validator?.call(PhoneNumber(
+            countryISOCode: _selectedCountry.code,
+            countryCode: '+${_selectedCountry.fullCountryCode}',
+            number: value ?? '',
+          ));
+        }
         if (value == null || !isNumeric(value)) return validatorMessage;
         if (!widget.disableLengthCheck) {
           return value.length >= _selectedCountry.minLength && value.length <= _selectedCountry.maxLength

--- a/lib/phone_number.dart
+++ b/lib/phone_number.dart
@@ -43,11 +43,11 @@ class PhoneNumber {
   bool isValidNumber() {
     Country country = getCountry(completeNumber);
     if (number.length < country.minLength) {
-      throw NumberTooShortException();
+      return false;
     }
 
     if (number.length > country.maxLength) {
-      throw NumberTooLongException();
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
## Problem

When associating the field to a form, validator does not get called unless onChange has been called at least once.

If a user submits a form without ever changing the field content then validator is never called and allows an empty field to
pass the validation.

When calling `bool isValidNumber()` false is never returned and exceptions should be caught instead.

## Workarounds

Expose the validator completely and allow parent widget to define custom validation to be run on form submission.
Remove asynchronous validation.

Return always true or false from `bool isValidNumber()` 



